### PR TITLE
PLATFORM-386: add in kruntime BYOC policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -397,6 +397,46 @@ data "aws_iam_policy_document" "doublecloud_kruntime_permissions" {
   }
 
   statement {
+    sid    = "EC2AllowAllDoubleCloudVPC"
+    effect = "Allow"
+    actions = [
+      "ec2:*"
+    ]
+    resources = [aws_vpc.doublecloud.arn]
+  }
+
+  statement {
+    sid    = "EC2AllowAllWithinDoubleCloudVPC"
+    effect = "Allow"
+    actions = [
+      "ec2:*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = [aws_vpc.doublecloud.arn]
+      variable = "ec2:Vpc"
+    }
+  }
+
+  statement {
+    sid    = "EC2AllowAllDoubleCloud"
+    effect = "Allow"
+    actions = [
+      "ec2:*"
+    ]
+    resources = [
+      "arn:aws:ec2:${local.region}:${local.account_id}:*/*",
+      "arn:aws:ec2:${local.region}::*/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      values   = ["true"]
+      variable = "aws:ResourceTag/AtDoubleCloud"
+    }
+  }
+
+  statement {
     sid    = "AutoscalingAllowAllKRuntime"
     effect = "Allow"
     actions = [

--- a/iam.tf
+++ b/iam.tf
@@ -581,7 +581,7 @@ data "aws_iam_policy_document" "doublecloud_ControlPlaneEKS_permissions" {
   }
 
   statement {
-    sid    = "AutoscalingAllowAllKRuntime"
+    sid    = "AutoscalingAllowAllControlplaneEKS"
     effect = "Allow"
     actions = [
       "autoscaling:*",

--- a/iam.tf
+++ b/iam.tf
@@ -3,9 +3,9 @@ locals {
   account_id = data.aws_caller_identity.self.account_id
 
   policy_arns = {
-    doublecloud          = "arn:aws:iam::${local.account_id}:policy/DoubleCloud/import-${aws_vpc.doublecloud.id}"
-    doublecloud_kruntime = "arn:aws:iam::${local.account_id}:policy/DoubleCloud/import-${aws_vpc.doublecloud.id}-kruntime"
-    permission_boundary  = "arn:aws:iam::${local.account_id}:policy/DoubleCloud/import-${aws_vpc.doublecloud.id}-permission-boundary"
+    doublecloud                 = "arn:aws:iam::${local.account_id}:policy/DoubleCloud/import-${aws_vpc.doublecloud.id}"
+    doublecloud_controlPlaneEKS = "arn:aws:iam::${local.account_id}:policy/DoubleCloud/import-${aws_vpc.doublecloud.id}-ControlPlaneEKS"
+    permission_boundary         = "arn:aws:iam::${local.account_id}:policy/DoubleCloud/import-${aws_vpc.doublecloud.id}-permission-boundary"
   }
   role_arn = "arn:aws:iam::${local.account_id}:role/DoubleCloud/import-${aws_vpc.doublecloud.id}"
 }
@@ -20,7 +20,7 @@ resource "aws_iam_role" "doublecloud" {
   permissions_boundary = aws_iam_policy.doublecloud_permission_boundary.arn
   managed_policy_arns = [
     aws_iam_policy.doublecloud.arn,
-    aws_iam_policy.doublecloud_kruntime.arn
+    aws_iam_policy.doublecloud_controlPlaneEKS.arn
   ]
 }
 
@@ -116,7 +116,7 @@ data "aws_iam_policy_document" "doublecloud_permission_boundary" {
     ]
     resources = [
       local.policy_arns[doublecloud],
-      local.policy_arns[doublecloud_kruntime]
+      local.policy_arns[doublecloud_controlPlaneEKS]
     ]
   }
 
@@ -469,14 +469,14 @@ data "aws_iam_policy_document" "doublecloud_permissions" {
   }
 }
 
-resource "aws_iam_policy" "doublecloud_kruntime" {
-  name = "import-${aws_vpc.doublecloud.id}-kruntime"
+resource "aws_iam_policy" "doublecloud_ControlPlaneEKS" {
+  name = "import-${aws_vpc.doublecloud.id}-ControlPlaneEKS"
   path = "/DoubleCloud/"
 
-  policy = data.aws_iam_policy_document.doublecloud_kruntime_permissions.json
+  policy = data.aws_iam_policy_document.doublecloud_ControlPlaneEKS_permissions.json
 }
 
-data "aws_iam_policy_document" "doublecloud_kruntime_permissions" {
+data "aws_iam_policy_document" "doublecloud_ControlPlaneEKS_permissions" {
   version = "2012-10-17"
 
   statement {

--- a/iam.tf
+++ b/iam.tf
@@ -14,7 +14,10 @@ resource "aws_iam_role" "doublecloud" {
 
   assume_role_policy   = data.aws_iam_policy_document.trusted_policy.json
   permissions_boundary = aws_iam_policy.doublecloud.arn
-  managed_policy_arns  = [aws_iam_policy.doublecloud.arn]
+  managed_policy_arns = [
+    aws_iam_policy.doublecloud.arn,
+    aws_iam_policy.doublecloud_kruntime.arn
+  ]
 }
 
 data "aws_iam_policy_document" "trusted_policy" {
@@ -318,6 +321,157 @@ data "aws_iam_policy_document" "doublecloud_permissions" {
       test     = "StringNotEquals"
       values   = [local.policy_arn]
       variable = "iam:PermissionsBoundary"
+    }
+  }
+}
+
+resource "aws_iam_policy" "doublecloud_kruntime" {
+  name = "import-${aws_vpc.doublecloud.id}-kruntime"
+  path = "/DoubleCloud/"
+
+  policy = data.aws_iam_policy_document.doublecloud_kruntime_permissions.json
+}
+
+data "aws_iam_policy_document" "doublecloud_kruntime_permissions" {
+  version = "2012-10-17"
+
+  statement {
+    sid = "EKSFullAccessDoubleCloud"
+    actions = [
+      "eks:*",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["true"]
+      variable = "aws:ResourceTag/AtDoubleCloud"
+    }
+  }
+
+  statement {
+    sid = "EKSAllowPassRolesDoubleCloud"
+    actions = [
+      "iam:PassRole",
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:iam::${local.account_id}:role/DoubleCloud/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["eks.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "EKSNodeGroupIAMPolicyDoubleCloud"
+    effect = "Allow"
+    actions = [
+      "iam:GetRole",
+      "iam:ListAttachedRolePolicies",
+    ]
+    resources = ["arn:aws:iam::${local.account_id}:role/DoubleCloud/*"]
+  }
+
+  statement {
+    sid       = "EKSAllowCreateServiceLinkedRole"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "iam:CreateServiceLinkedRole"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values = [
+        "autoscaling.amazonaws.com",
+        "ec2scheduled.amazonaws.com",
+        "elasticloadbalancing.amazonaws.com",
+        "eks.amazonaws.com",
+        "eks-fargate-pods.amazonaws.com",
+        "eks-nodegroup.amazonaws.com",
+        "spot.amazonaws.com",
+        "spotfleet.amazonaws.com",
+        "transitgateway.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AutoscalingAllowAllKRuntime"
+    effect = "Allow"
+    actions = [
+      "autoscaling:*",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["kruntime-platform"]
+      variable = "aws:ResourceTag/eks:nodegroup-name"
+    }
+  }
+
+  statement {
+    sid    = "ElasticLoadBalancingAllowAllDoubleCloud"
+    effect = "Allow"
+    actions = [
+      "elasticloadbalancing:*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["true"]
+      variable = "aws:ResourceTag/AtDoubleCloud"
+    }
+  }
+
+  statement {
+    sid    = "ACMAccessDoubleCloud"
+    effect = "Allow"
+    actions = [
+      "acm:RequestCertificate",
+      "acm:DescribeCertificate",
+      "acm:ListCertificates",
+      "acm:DeleteCertificate",
+      "acm:ListTagsForCertificate",
+      "acm:AddTagsToCertificate",
+      "acm:RemoveTagsFromCertificate",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["true"]
+      variable = "aws:ResourceTag/AtDoubleCloud"
+    }
+  }
+
+  statement {
+    sid    = "RDSAccessDoubleCloud"
+    effect = "Allow"
+    actions = [
+      "rds:AddTagsToResource",
+
+      "rds:DescribeDBSubnetGroups",
+      "rds:DescribeDBClusters",
+      "rds:DescribeDBInstances",
+
+      "rds:CreateDBInstance",
+      "rds:CreateDBCluster",
+      "rds:DeleteDBInstance",
+      "rds:DeleteDBCluster",
+
+      "rds:StartDBInstance",
+      "rds:StartDBCluster",
+      "rds:StopDBInstance",
+      "rds:StopDBCluster",
+
+      "rds:CreateDBSubnetGroup",
+      "rds:DeleteDBSubnetGroup",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["true"]
+      variable = "aws:ResourceTag/AtDoubleCloud"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 4.51.0"
     }
     time = {
-      source = "hashicorp/time"
+      source  = "hashicorp/time"
       version = ">= 0.9.1"
     }
   }


### PR DESCRIPTION
Notes:
- adds in new permissionBoundary distinct from actual policy
    - follows the pattern of deny statements for given resource before allow statements
    - note that this does not grant permissions to act, rather it acts a boundary of what permissions the role can have from the underlying policies, therefore it is more general (by design)
- `EKSAllowPassRolesDoubleCloud` statement assumes that the roles being passed are under the path `DoubleCloud` in customer's account
- ASGs created via EKS cannot be tagged directly, therefore using 
```
    condition {
      test     = "StringEquals"
      values   = ["kruntime-platform"]
      variable = "aws:ResourceTag/eks:nodegroup-name"
    }
```
- finally this policy is being attached to the existing role, therefore it assumes the other role exists (and therefore does not redefine the EC2 permissions)

Once all good here we can rollout to the CloudFormation Template