### PR TITLE
TRANSFER-548: Add missing KMS and RDS permissions

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -649,6 +649,12 @@ data "aws_iam_policy_document" "doublecloud_airflow" {
   }
 
   statement {
+    effect    = "Allow"
+    actions   = ["kms:CreateAlias"]
+    resources = ["arn:aws:kms:${local.region}:${local.account_id}:alias/airflow-afc*"]
+  }
+
+  statement {
     effect = "Allow"
     actions = [
       "rds:AddTagsToResource",
@@ -672,12 +678,6 @@ data "aws_iam_policy_document" "doublecloud_airflow" {
       "arn:aws:s3:::airflow-remote-logging-*",
       "arn:aws:s3:::airflow-remote-logging-*/*",
     ]
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["kms:CreateAlias"]
-    resources = ["arn:aws:kms:${local.region}:${local.account_id}:alias/airflow-afc*"]
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -655,6 +655,7 @@ data "aws_iam_policy_document" "doublecloud_airflow" {
       "rds:CreateDBInstance",
       "rds:CreateDBCluster",
       "rds:CreateDBParameterGroup",
+      "rds:ModifyDBParameterGroup",
     ]
     resources = [
       "arn:aws:rds:${local.region}:${local.account_id}:*:airflow-afc*",
@@ -671,6 +672,12 @@ data "aws_iam_policy_document" "doublecloud_airflow" {
       "arn:aws:s3:::airflow-remote-logging-*",
       "arn:aws:s3:::airflow-remote-logging-*/*",
     ]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:CreateAlias"]
+    resources = ["arn:aws:kms:${local.region}:${local.account_id}:alias/airflow-afc*"]
   }
 }
 


### PR DESCRIPTION
`kms:CreateAlias` and `rds:ModifyDBParameterGroup` permissions were missing from Airflow BYOA permissions set