### PR TITLE
TRANSFER-849: Allow db instance modification

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -661,6 +661,7 @@ data "aws_iam_policy_document" "doublecloud_airflow" {
       "rds:CreateDBInstance",
       "rds:CreateDBCluster",
       "rds:CreateDBParameterGroup",
+      "rds:ModifyDBInstance",
       "rds:ModifyDBParameterGroup",
     ]
     resources = [


### PR DESCRIPTION
To support environment flavor modification, worker needs to be allowed to change DB instances.